### PR TITLE
make regexp to remove control characters more permissive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 npm-debug.log
 .DS_Store
-lib

--- a/lib/suspect.d.ts
+++ b/lib/suspect.d.ts
@@ -1,0 +1,32 @@
+/// <reference types="node" />
+import { ChildProcess } from "child_process";
+export interface ISpawnOptions {
+    cwd?: string;
+    env?: any;
+    stdio?: any;
+    detached?: boolean;
+    uid?: number;
+    gid?: number;
+    stream?: string;
+    shell?: boolean | string;
+}
+export interface ISpawnFunction {
+    callback: (data?: string) => boolean | void;
+    type: string;
+    description: string;
+    expected?: string | RegExp;
+}
+export declare class SpawnChain {
+    private command;
+    private args;
+    private options;
+    private queue;
+    private process;
+    constructor(command: string, args: string[], options: ISpawnOptions);
+    expect(expectation: string | RegExp): SpawnChain;
+    wait(expectation: string | RegExp, callback?: (_: string) => void): SpawnChain;
+    sendline(line: string): SpawnChain;
+    sendEof(): SpawnChain;
+    run(callback: (err?: Error, output?: string[], exit?: string | number) => void): ChildProcess;
+}
+export declare function spawn(command: string, args?: string[], options?: ISpawnOptions): SpawnChain;

--- a/lib/suspect.js
+++ b/lib/suspect.js
@@ -1,0 +1,196 @@
+"use strict";
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) if (e.indexOf(p[i]) < 0)
+            t[p[i]] = s[p[i]];
+    return t;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var assert_1 = require("assert");
+var child_process_1 = require("child_process");
+var SpawnChain = /** @class */ (function () {
+    function SpawnChain(command, args, options) {
+        this.command = command;
+        this.args = args;
+        this.options = options;
+        this.queue = [];
+    }
+    SpawnChain.prototype.expect = function (expectation) {
+        this.queue.push({
+            callback: function (data) {
+                if (typeof expectation === "string") {
+                    return data.indexOf(expectation) > -1;
+                }
+                return expectation.test(data);
+            },
+            description: "[expect] " + expectation,
+            expected: expectation,
+            type: "expect",
+        });
+        return this;
+    };
+    SpawnChain.prototype.wait = function (expectation, callback) {
+        if (callback === void 0) { callback = function (_) { }; }
+        this.queue.push({
+            callback: function (data) {
+                var match = false;
+                if (typeof expectation === "string") {
+                    match = data.indexOf(expectation) > -1;
+                }
+                else {
+                    match = expectation.test(data);
+                }
+                if (match) {
+                    callback(data);
+                }
+                return match;
+            },
+            description: "[wait] " + expectation,
+            type: "wait",
+        });
+        return this;
+    };
+    SpawnChain.prototype.sendline = function (line) {
+        var self = this;
+        this.queue.push({
+            callback: function () { self.process.stdin.write(line + "\n"); },
+            description: "[sendline] " + line,
+            type: "sendline",
+        });
+        return this;
+    };
+    SpawnChain.prototype.sendEof = function () {
+        var self = this;
+        this.queue.push({
+            callback: function () { self.process.stdin.destroy(); },
+            description: "[sendEof]",
+            type: "eof",
+        });
+        return this;
+    };
+    SpawnChain.prototype.run = function (callback) {
+        var self = this;
+        var failed = false;
+        var stdout = [];
+        function onError(err, kill) {
+            if (kill) {
+                try {
+                    self.process.kill();
+                }
+                catch (ex) { }
+            }
+            if (failed) {
+                return;
+            }
+            failed = true;
+            callback(err);
+        }
+        function evalQueue(previousType, data) {
+            if (typeof data === "undefined") {
+                return;
+            }
+            var currentFn = self.queue[0];
+            if (!currentFn || ((previousType === "expect" || previousType === "wait") && currentFn.type === "expect")) {
+                return;
+            }
+            switch (currentFn.type) {
+                case "expect":
+                    self.queue.shift();
+                    if (currentFn.callback(data)) {
+                        return evalQueue("expect", data);
+                    }
+                    var message = (typeof currentFn.expected === "string") ? "to contain" : "to match";
+                    return new assert_1.AssertionError({
+                        actual: data,
+                        expected: currentFn.expected,
+                        message: "expected " + data + " " + message + " " + currentFn.expected,
+                    });
+                case "wait":
+                    if (currentFn.callback(data)) {
+                        self.queue.shift();
+                        return evalQueue("wait", data);
+                    }
+                    return;
+                default:
+                    self.queue.shift();
+                    currentFn.callback();
+                    var nextFn = self.queue[0];
+                    if (nextFn && ["expect", "wait"].indexOf(nextFn.type) === -1) {
+                        return evalQueue(currentFn.type, data);
+                    }
+                    return;
+            }
+        }
+        function handleData(data) {
+            data = data.toString().replace(/\u001b\[\d{0,2}./g, "");
+            var lines = data.split("\n").filter(function (line) { return line.length > 0; });
+            stdout = stdout.concat(lines);
+            while (lines.length > 0) {
+                var err = evalQueue("start", lines.shift());
+                if (err) {
+                    onError(err, true);
+                    break;
+                }
+            }
+        }
+        function flushQueue() {
+            var remainingQueue = self.queue.slice();
+            var currentFn = self.queue.shift();
+            var lastLine = stdout[stdout.length - 1];
+            if (!lastLine) {
+                onError(new assert_1.AssertionError({
+                    actual: remainingQueue.map(function (fn) { return fn.description; }),
+                    expected: [],
+                    message: "No data from child with non-empty queue.",
+                }));
+                return false;
+            }
+            else if (self.queue.length > 0) {
+                onError(new assert_1.AssertionError({
+                    actual: remainingQueue.map(function (fn) { return fn.description; }),
+                    expected: [],
+                    message: "Non-empty queue on spawn exit.",
+                }));
+                return false;
+            }
+            else if (currentFn && currentFn.type === "sendline") {
+                onError(new Error("Cannot call sendline after the process has exited"));
+                return false;
+            }
+            else if (currentFn && currentFn.type === "wait" || currentFn.type === "expect") {
+                if (currentFn.callback(lastLine) !== true) {
+                    var message = (typeof currentFn.expected === "string") ? "to contain" : "to match";
+                    onError(new assert_1.AssertionError({
+                        actual: lastLine,
+                        expected: currentFn.expected,
+                        message: "expected " + lastLine + " " + message + " " + currentFn.expected,
+                    }));
+                    return false;
+                }
+            }
+            return true;
+        }
+        var _a = self.options, stream = _a.stream, options = __rest(_a, ["stream"]);
+        self.process = child_process_1.spawn(self.command, self.args, options);
+        self.process[stream || "stdout"].on("data", handleData);
+        self.process.on("error", onError);
+        self.process.on("close", function (code, signal) {
+            if (self.queue.length && !flushQueue()) {
+                return;
+            }
+            callback(undefined, stdout, signal || code);
+        });
+        return self.process;
+    };
+    return SpawnChain;
+}());
+exports.SpawnChain = SpawnChain;
+function spawn(command, args, options) {
+    if (args === void 0) { args = []; }
+    if (options === void 0) { options = {}; }
+    return new SpawnChain(command, args, options);
+}
+exports.spawn = spawn;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "http://github.com/andrewstucki/node-suspect.git"
   },
+	"files": [
+		"lib"
+	],
   "keywords": [
     "spawn",
     "child process",
@@ -35,5 +38,6 @@
     "ts-node": "^3.3.0",
     "tslint": "^5.7.0",
     "typescript": "^2.5.3"
-  }
+  },
+  "dependencies": {}
 }

--- a/src/suspect.ts
+++ b/src/suspect.ts
@@ -151,7 +151,7 @@ export class SpawnChain {
     }
 
     function handleData(data: string) {
-      data = data.toString().replace(/\u001b\[\d{0,2}m/g, "");
+      data = data.toString().replace(/\u001b\[\d{0,2}./g, "");
       const lines = data.split("\n").filter((line) => line.length > 0);
       stdout = stdout.concat(lines);
 


### PR DESCRIPTION
This allows stripping all control characters from stdout, especially useful when working with inquirer and libraries of that ilk, where the control characters are added by an intermediate library, not the user. 